### PR TITLE
Update docs to avoid getting two Redux stores

### DIFF
--- a/source/redux.md
+++ b/source/redux.md
@@ -36,8 +36,10 @@ const store = createStore(
   )
 );
 
+client.setStore(store);
+
 ReactDOM.render(
-  <ApolloProvider store={store} client={client}>
+  <ApolloProvider client={client}>
     <MyRootComponent />
   </ApolloProvider>,
   rootEl


### PR DESCRIPTION
If setStore is not called Apollo will create its own store as well as your redux store. This will result in a confusing experience in Redux devtools.