### PR TITLE
change implied query name to reduce confusion

### DIFF
--- a/source/optimistic-ui.md
+++ b/source/optimistic-ui.md
@@ -91,7 +91,7 @@ const CommentsPageWithMutations = graphql(SUBMIT_COMMENT_MUTATION, {
             },
           },
           updateQueries: {
-            Comment: (previousResult, { mutationResult }) => {
+            comment: (previousResult, { mutationResult }) => {
               const newComment = mutationResult.data.submitComment;
               return update(previousResult, {
                 entry: {

--- a/source/optimistic-ui.md
+++ b/source/optimistic-ui.md
@@ -91,7 +91,9 @@ const CommentsPageWithMutations = graphql(SUBMIT_COMMENT_MUTATION, {
             },
           },
           updateQueries: {
-            comment: (previousResult, { mutationResult }) => {
+            // Would update the query that looks like:
+            // query CommentQuery { ... }
+            CommentQuery: (previousResult, { mutationResult }) => {
               const newComment = mutationResult.data.submitComment;
               return update(previousResult, {
                 entry: {


### PR DESCRIPTION
I think it would be helpful to make it clear that params of `updateQueries` first arg are the names of queries. 

In the example in the docs, there is an implied query named Comment, but the type Comment is also returned by the `submitComment` mutation. It wasn't clear to me that the param refers to queries and not the return type of the mutation, especially since the `optimisticResponse` params are all about type. Took investigating the docs to realize why updateQueries wasn't executing.

The easiest way I can think of showing this without making the example more complex is just renaming the query :)