### PR TITLE
Update Redux devtools setup syntax

### DIFF
--- a/source/redux.md
+++ b/source/redux.md
@@ -32,7 +32,7 @@ const store = createStore(
   compose(
       applyMiddleware(client.middleware()),
       // If you are using the devToolsExtension, you can add it here also
-      window.devToolsExtension ? window.devToolsExtension() : f => f,
+      window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
   )
 );
 


### PR DESCRIPTION
As https://github.com/zalmoxisus/redux-devtools-extension#usage docs states, `window.devToolsExtension` has been renamed and will be deprecated in the future. I just stumbled upon this, while setting up my latest project, so I'm not sure if I can just propose a change like this here.. Let me know in case I'm trying to contribute in a wrong way.

And keep up the great work, Apollo Client is awesome!