### PR TITLE
use typeof to check for redux devtools

### DIFF
--- a/source/redux.md
+++ b/source/redux.md
@@ -32,7 +32,7 @@ const store = createStore(
   compose(
       applyMiddleware(client.middleware()),
       // If you are using the devToolsExtension, you can add it here also
-      window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+      (typeof window.__REDUX_DEVTOOLS_EXTENSION__ !== 'undefined') ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f,
   )
 );
 


### PR DESCRIPTION
The original `window.__REDUX_DEVTOOLS_EXTENSION__ && ...` was breaking my app in browsers without this extension.

I'm not sure how other parts of my app are influencing the problem that is caused by this but I can't be alone. I'm using create-react-app not ejected. 