### PR TITLE
Fixes code example

### DIFF
--- a/source/initialization.md
+++ b/source/initialization.md
@@ -35,7 +35,7 @@ import { ApolloClient, createNetworkInterface } from 'react-apollo';
 
 const networkInterface = createNetworkInterface({
   uri: 'http://api.example.com/graphql'
-}),
+});
 
 const client = new ApolloClient({
   networkInterface: networkInterface


### PR DESCRIPTION
Replaces a bogus `,` for an end-of-line `;` in client instantiation example