### PR TITLE
Fix 'response' typo & add hyphen to refer to possible response types

### DIFF
--- a/source/api-mutations.md
+++ b/source/api-mutations.md
@@ -175,7 +175,7 @@ export default graphql(gql`
 
 This option allows you to update your store based on your mutation’s result. By default Apollo Client will update all of the overlapping nodes in your store. Anything that shares the same id as returned by the `dataIdFromObject` you defined will be updated with the new fields from your mutation results. However, sometimes this alone is not sufficient. Sometimes you may want to update your cache in a way that is dependent on the data currently in your cache. For these updates you may use an `options.update` function.
 
-`options.update` takes two arguments. The first is an instance of a [`DataProxy`][] object which has some methods which will allow you to interact with the data in your store. The second is the respone from your mutation. Either the optimistic response, or the actual response returned by your server.
+`options.update` takes two arguments. The first is an instance of a [`DataProxy`][] object which has some methods which will allow you to interact with the data in your store. The second is the response from your mutation - either the optimistic response, or the actual response returned by your server.
 
 In order to change the data in your store call methods on your [`DataProxy`][] instance like [`writeQuery`][] and [`writeFragment`][]. This will update your cache and reactively re-render any of your GraphQL components which are querying affected data.
 


### PR DESCRIPTION
`source/api-mutations.md` has a typo for the word `response` (typed as `respone`).

This PR fixes the typo and adds a hyphen to refer to the possible response types it refers to afterward.