### PR TITLE
Change the endpoint URI example to the less misleading one

### DIFF
--- a/source/subscriptions.md
+++ b/source/subscriptions.md
@@ -83,7 +83,7 @@ import { SubscriptionClient, addGraphQLSubscriptions } from 'subscriptions-trans
 
 // Create a normal network interface:
 const networkInterface = createNetworkInterface({
-  uri: 'http://localhost:3000'
+  uri: 'http://localhost:3000/graphql'
 });
 
 // Extend the network interface with the WebSocket


### PR DESCRIPTION
People don't usually use `http://localhost:3000/` as their endpoint for graphql,
I think it might be more understandable what it is if we use `http://localhost:3000/graphql` as example.