### PR TITLE
Fix broken `config.option` links

### DIFF
--- a/source/api-graphql.md
+++ b/source/api-graphql.md
@@ -104,7 +104,7 @@ Lets go through all of the properties that may live on your `config` object.
 
 `config.options` is an object or a function that allows you to define the specific behavior your component should use in handling your GraphQL data.
 
-The specific options available for configuration depend on the operation you pass as the first argument to `graphql()`. There are options specific to [queries](#graphql-query-options) and [mutations](#graphql-mutation-options).
+The specific options available for configuration depend on the operation you pass as the first argument to `graphql()`. There are options specific to [queries](api-queries.html#graphql-query-options) and [mutations](api-mutations.html#graphql-mutation-options).
 
 You can define `config.options` as a plain object, or you can compute your options from a function that takes the component’s props as an argument.
 

--- a/source/api-queries.md
+++ b/source/api-queries.md
@@ -248,14 +248,14 @@ class SubscriptionComponent extends Component {
     if(!nextProps.data.loading) {
       // Check for existing subscription
       if (this.unsubscribe) {
-        // Check if props have changed and, if necessary, stop the subscription    
+        // Check if props have changed and, if necessary, stop the subscription
         if (this.props.subscriptionParam !== nextProps.subscriptionParam) {
-          this.unsubscribe();     
+          this.unsubscribe();
         } else {
           return;
         }
       }
-    
+
       // Subscribe
       this.unsubscribe = nextProps.data.subscribeToMore({
         document: gql`subscription {...}`,
@@ -360,7 +360,7 @@ An object or function that returns an object of options that are used to configu
 
 If `config.options` is a function then it will take the component’s props as its first argument.
 
-The options available for use  in this object depend on the operation type you pass in as the first argument to `graphql()`. The references below will document which options are availble when your operation is a query. To see what other options are available for different operations, see the generic documentation for [`config.options`](#graphql-config-options).
+The options available for use  in this object depend on the operation type you pass in as the first argument to `graphql()`. The references below will document which options are availble when your operation is a query. To see what other options are available for different operations, see the generic documentation for [`config.options`](api-graphql.html#graphql-config-options).
 
 **Example:**
 


### PR DESCRIPTION
I noticed a couple of the anchor links were not pointing to their correct URLs, this should fix the problem! I _believe_ the second commit also fixes the broken generic `config.options` link, but I wasn't 100% sure if it was pointing to the correct reference.