### PR TITLE
Change PROFILE_QUERY options

### DIFF
--- a/source/auth.md
+++ b/source/auth.md
@@ -139,7 +139,7 @@ const PROFILE_QUERY = gql`
 `;
 
 export default withApollo(graphql(PROFILE_QUERY, {
-  options: { forceFetch: true },
+  options: { fetchPolicy: 'cache-and-network' },
   props: ({ data: { loading, currentUser } }) => ({
     loading, currentUser,
   }),


### PR DESCRIPTION
If I understand correctly, the `forcheFetch` option is deprecated. I changed the `forcheFetch` to `fetchPolicy`. I hope that I chose the right policy. If not, tell me the correct option please.