### PR TITLE
Fixed header option

### DIFF
--- a/source/auth.md
+++ b/source/auth.md
@@ -48,7 +48,7 @@ const networkInterface = createNetworkInterface({
 networkInterface.use([{
   applyMiddleware(req, next) {
     if (!req.options.headers) {
-      req.options.headers = {};  // Create the header object if needed.
+      req.options.headers = new Headers();  // Create the header object if needed.
     }
 
     // get the authentication token from local storage if it exists


### PR DESCRIPTION
Spent a while trying to set the authorization header of my requests, realized from https://github.com/apollographql/apollo-client/issues/253 that I needed to set req.options.headers = new Headers() instead of req.options.headers = {}. Once I did that, it worked
No idea if this affected anyone else, so might just be me