### PR TITLE
Remove wording about "just like above"

### DIFF
--- a/source/optimistic-ui.md
+++ b/source/optimistic-ui.md
@@ -51,7 +51,7 @@ We select `id` and `__typename` because that's what our `dataIdFromObject` uses 
 
 In the example above, we showed how to seamlessly edit an existing object in the store with an optimistic mutation result. However, many mutations don't just update an existing object in the store, but they insert a new one.
 
-In that case we need to specify how to integrate the new data into existing queries, and thus our UI. You can read in detail about how to do that in the article about [controlling the store](cache-updates.html)--in particular, we can use the `update` function to insert a result into an existing query's result set. `update` works exactly the same way for optimistic results and the real results returned from the server, so just like above we only need to add the `optimisticResponse` option.
+In that case we need to specify how to integrate the new data into existing queries, and thus our UI. You can read in detail about how to do that in the article about [controlling the store](cache-updates.html)--in particular, we can use the `update` function to insert a result into an existing query's result set. `update` works exactly the same way for optimistic results and the real results returned from the server.
 
 Here is a concrete example from GitHunt, which inserts a comment into an existing list of comments.
 


### PR DESCRIPTION
The previous example is actually only implementing `optimisticResponse` but then the next example implements `update` as well as `optimisticResponse`, and I found the wording to be a bit confusing around this. Do we need to implement `update` as well as `optimisticResponse` as the example shows for adding to a list? If so, the wording was incorrect. If not, then it'd be ideal to give an example where only `optimisticResponse` is required for adding to a list.

I'm currently assuming that the wording was actually slightly off, and that `update` was in fact necessary, in which case we can just remove the bit about `update` not being required.