### PR TITLE
fix example; cursor is not available on root

### DIFF
--- a/source/pagination.md
+++ b/source/pagination.md
@@ -125,7 +125,7 @@ const MoreCommentsQuery = gql`
   }
 `;
 
-const CommentsWithData = graphql(Comment, {
+const CommentsWithData = graphql(CommentsQuery, {
   // This function re-runs every time `data` changes, including after `updateQuery`,
   // meaning our loadMoreEntries function will always have the right cursor
   props({ data: { loading, cursor, comments, fetchMore } }) {
@@ -145,7 +145,7 @@ const CommentsWithData = graphql(Comment, {
             return {
               // By returning `cursor` here, we update the `loadMore` function
               // to the new cursor.
-              cursor: fetchMoreResult.cursor,
+              cursor: fetchMoreResult.moreComments.cursor,
 
               entry: {
                 // Put the new comments in the front of the list
@@ -157,7 +157,7 @@ const CommentsWithData = graphql(Comment, {
       },
     };
   },
-})(Feed);
+})(Comments);
 ```
 
 <h2 id="relay-cursors">Relay-style cursor pagination</h2>

--- a/source/pagination.md
+++ b/source/pagination.md
@@ -141,15 +141,16 @@ const CommentsWithData = graphql(CommentsQuery, {
           updateQuery: (previousResult, { fetchMoreResult }) => {
             const previousEntry = previousResult.entry;
             const newComments = fetchMoreResult.moreComments.comments;
+            const newCursor = fetchMoreResult.moreComments.cursor;
 
             return {
               // By returning `cursor` here, we update the `loadMore` function
               // to the new cursor.
-              cursor: fetchMoreResult.moreComments.cursor,
+              cursor: newCursor,
 
               entry: {
                 // Put the new comments in the front of the list
-                comments: [...newComments, ...previousEntry.entry.comments],
+                comments: [...newComments, ...previousEntry.comments],
               },
             };
           },


### PR DESCRIPTION
The example suggested that `cursor` would be returned alongside `moreComments`, but in reality the cursor is returned as a field of `moreComments`.

I also updated some ambiguous naming