### PR TITLE
Update SSR for React docs to reflect newest version of React Router

### DIFF
--- a/source/server-side-rendering.md
+++ b/source/server-side-rendering.md
@@ -70,52 +70,89 @@ We'll see how to take your component tree and turn it into a string in the next 
 Once you put that all together, you'll end up with initialization code that looks like this:
 
 ```js
+/* This example uses React Router v4, although it should work equally well with other
+   routers that support SSR
+*/
+
 import { ApolloClient, createNetworkInterface, ApolloProvider } from 'react-apollo';
 import Express from 'express';
-import { match, RouterContext } from 'react-router';
-
-// A Routes file is a good shared entry-point between client and server
-import routes from './routes';
+import { StaticRouter } from 'react-router';
+import App from './app';
 
 // Note you don't have to use any particular http server, but
 // we're using Express in this example
 const app = new Express();
 app.use((req, res) => {
 
-  // This example uses React Router, although it should work equally well with other
-  // routers that support SSR
-  match({ routes, location: req.originalUrl }, (error, redirectLocation, renderProps) => {
 
-    const client = new ApolloClient({
-      ssrMode: true,
-      // Remember that this is the interface the SSR server will use to connect to the
-      // API server, so we need to ensure it isn't firewalled, etc
-      networkInterface: createNetworkInterface({
-        uri: 'http://localhost:3010',
-        opts: {
-          credentials: 'same-origin',
-          headers: {
-            cookie: req.header('Cookie'),
-          },
+  const client = new ApolloClient({
+    ssrMode: true,
+    // Remember that this is the interface the SSR server will use to connect to the
+    // API server, so we need to ensure it isn't firewalled, etc
+    networkInterface: createNetworkInterface({
+      uri: 'http://localhost:3010',
+      opts: {
+        credentials: 'same-origin',
+        headers: {
+          cookie: req.header('Cookie'),
         },
-      }),
-    });
-
-    const app = (
-      <ApolloProvider client={client}>
-        <RouterContext {...renderProps} />
-      </ApolloProvider>
-    );
-
-    // rendering code (see below)
+      },
+    }),
   });
+
+  const context = {};
+
+  // The client-side app will instead use <BrowserRouter>
+  const app = (
+    <StaticRouter location={req.url} context={context}>
+      <App />
+    </StaticRouter>
+  );
+
+  // rendering code (see below)
 });
 
 app.listen(basePort, () => console.log( // eslint-disable-line no-console
   `App Server is now running on http://localhost:${basePort}`
 ));
 ```
-You can check out the [GitHunt app's `ui/server.js`](https://github.com/apollographql/GitHunt-React/blob/master/ui/server.js) for a complete working example.
+
+```js
+// app.jsx
+
+import { Route, Switch } from 'react-router';
+import { Link } from 'react-router-dom';
+import React from 'react';
+import routes from './routes';
+
+const App = () =>
+  <div>
+    <nav>
+      <ul>
+        <li>
+          <Link to="/">Home</Link>
+        </li>
+        <li>
+          <Link to="/another">Another page</Link>
+        </li>
+      </ul>
+    </nav>
+
+    /* New <Switch> behavior introduced in React Router v4
+       https://reacttraining.com/react-router/web/api/Switch
+    */
+    <Switch>
+      {routes.map(props => <Route {...props} />)}
+    </Switch>
+  </div>;
+
+export default App;
+
+```
+
+
+
+You can check out the [GitHunt app's `ui/server.js`](https://github.com/apollographql/GitHunt-React/blob/master/ui/server.js) for a complete working example with React Router v3, which has a slightly different API.
 
 Next we'll see what that rendering code actually does.
 

--- a/source/server-side-rendering.md
+++ b/source/server-side-rendering.md
@@ -70,9 +70,8 @@ We'll see how to take your component tree and turn it into a string in the next 
 Once you put that all together, you'll end up with initialization code that looks like this:
 
 ```js
-/* This example uses React Router v4, although it should work equally well with other
-   routers that support SSR
-*/
+// This example uses React Router v4, although it should work
+// equally well with other routers that support SSR
 
 import { ApolloClient, createNetworkInterface, ApolloProvider } from 'react-apollo';
 import Express from 'express';
@@ -140,19 +139,16 @@ const App = () =>
       </ul>
     </nav>
 
-    /* New <Switch> behavior introduced in React Router v4
-       https://reacttraining.com/react-router/web/api/Switch
-    */
+    {/* New <Switch> behavior introduced in React Router v4
+       https://reacttraining.com/react-router/web/api/Switch */}
     <Switch>
-      {routes.map(props => <Route {...props} />)}
+      {routes.map(route => <Route key={route.name} {...route} />)}
     </Switch>
   </div>;
 
 export default App;
 
 ```
-
-
 
 You can check out the [GitHunt app's `ui/server.js`](https://github.com/apollographql/GitHunt-React/blob/master/ui/server.js) for a complete working example with React Router v3, which has a slightly different API.
 

--- a/source/server-side-rendering.md
+++ b/source/server-side-rendering.md
@@ -123,6 +123,8 @@ app.listen(basePort, () => console.log( // eslint-disable-line no-console
 import { Route, Switch } from 'react-router';
 import { Link } from 'react-router-dom';
 import React from 'react';
+
+// A Routes file is a good shared entry-point between client and server
 import routes from './routes';
 
 const App = () =>

--- a/source/server-side-rendering.md
+++ b/source/server-side-rendering.md
@@ -76,7 +76,7 @@ Once you put that all together, you'll end up with initialization code that look
 import { ApolloClient, createNetworkInterface, ApolloProvider } from 'react-apollo';
 import Express from 'express';
 import { StaticRouter } from 'react-router';
-import App from './app';
+import Layout from './routes/Layout';
 
 // Note you don't have to use any particular http server, but
 // we're using Express in this example
@@ -103,9 +103,11 @@ app.use((req, res) => {
 
   // The client-side app will instead use <BrowserRouter>
   const app = (
-    <StaticRouter location={req.url} context={context}>
-      <App />
-    </StaticRouter>
+    <ApolloProvider client={client}>
+      <StaticRouter location={req.url} context={context}>
+        <Layout />
+      </StaticRouter>
+    </ApolloProvider>
   );
 
   // rendering code (see below)
@@ -117,7 +119,7 @@ app.listen(basePort, () => console.log( // eslint-disable-line no-console
 ```
 
 ```js
-// app.jsx
+// ./routes/Layout.js
 
 import { Route, Switch } from 'react-router';
 import { Link } from 'react-router-dom';
@@ -126,7 +128,7 @@ import React from 'react';
 // A Routes file is a good shared entry-point between client and server
 import routes from './routes';
 
-const App = () =>
+const Layout = () =>
   <div>
     <nav>
       <ul>
@@ -146,7 +148,31 @@ const App = () =>
     </Switch>
   </div>;
 
-export default App;
+export default Layout;
+
+```
+
+```js
+// ./routes/index.js
+
+import MainPage from './MainPage';
+import AnotherPage from './AnotherPage';
+
+const routes = [
+  {
+    path: '/',
+    name: 'home',
+    exact: true,
+    component: MainPage,
+  },
+  {
+    path: '/another',
+    name: 'another',
+    component: AnotherPage,
+  },
+];
+
+export default routes;
 
 ```
 


### PR DESCRIPTION
The existing docs show an example using React Router v3, which has a pretty different API than v4. I just got this working for v4, so let me know if anything seems unclear. 