### PR TITLE
Add link to FuseBox plugin

### DIFF
--- a/source/webpack.md
+++ b/source/webpack.md
@@ -49,6 +49,10 @@ export default graphql(currentUserQuery)(Profile)
 
 [Jest](https://facebook.github.io/jest/) can't use the Webpack loaders. To make the same transformation work in Jest, use [jest-transform-graphql](https://github.com/remind101/jest-transform-graphql).
 
+## FuseBox
+
+[FuseBox](http://fuse-box.org) can't use the Webpack loaders. To make the same transformation work in FuseBox, use [fuse-box-graphql-plugin](https://github.com/otothea/fuse-box-graphql-plugin).
+
 ## Fragments
 
 You can use and include fragments in .graphql files and have webpack include those dependencies for you, similar to how you would use fragments and queries with the gql tag in plain JS.


### PR DESCRIPTION
I have been using apollo-client and webpack on a project, but we are switching to use the FuseBox bundler and had to create a plugin to work with your webpack loader. I saw the link for the Jest loader and thought I might share the FuseBox loader here as well.