### PR TITLE
Add gql to the list of imports

### DIFF
--- a/source/auth.md
+++ b/source/auth.md
@@ -75,7 +75,7 @@ Another option is to reload the page, which will have a similar effect.
 
 
 ```js
-import { withApollo, graphql } from 'react-apollo';
+import { withApollo, graphql, gql } from 'react-apollo';
 import ApolloClient from 'apollo-client';
 
 class Profile extends React.Component {


### PR DESCRIPTION
gql is used to create the graphql query for the Profile component so it has to be imported to work.