### PR TITLE
Small typo in refetchQueries example

### DIFF
--- a/source/cache-updates.md
+++ b/source/cache-updates.md
@@ -106,7 +106,7 @@ mutate({
         }
       }
     `,
-    variables: { repoFullName: 'apollographql/apollo-client' },
+    variables: { repoName: 'apollographql/apollo-client' },
   }],
 })
 ```


### PR DESCRIPTION
Small typo in refetchQueries example. The variable name is incorrect in the mutation of refetchQueries example.