### PR TITLE
Update auth.md with minor fixes

### DIFF
--- a/source/auth.md
+++ b/source/auth.md
@@ -75,8 +75,7 @@ Another option is to reload the page, which will have a similar effect.
 
 
 ```js
-import { withApollo, graphql, gql } from 'react-apollo';
-import ApolloClient from 'apollo-client';
+import { ApolloClient, withApollo, graphql, gql } from 'react-apollo';
 
 class Profile extends React.Component {
   constructor(props) {
@@ -85,7 +84,7 @@ class Profile extends React.Component {
     this.logout = () => {
       App.logout() // or whatever else your logout flow is
       .then(() =>
-        props.client.resetStore();
+        props.client.resetStore()
       )
       .catch(err =>
         console.error('Logout failed', err);


### PR DESCRIPTION
This PR fixes couple of minor issues in `auth.md`.

1. Remove unexpected `;` from an example

2. Use the `ApolloClient` in `react-apollo` instead of `apollo-client`. If one is using `react-apollo`, chances are that they are also using the `ApolloClient` in the same package instead of the standalone one. The current example fails the proptype check in this case, as `client` is an instance of the `ApolloClient` in `react-apollo`, which raises quite 🤔 error message too (`Warning: Invalid prop `client` of type `ApolloClient` supplied to `Foo`, expected instance of `ApolloClient`).