### PR TITLE
Fix broken Githunt example links

### DIFF
--- a/source/fragments.md
+++ b/source/fragments.md
@@ -78,7 +78,7 @@ export const COMMENT_QUERY = gql`
 `;
 ```
 
-You can see the full source code to the `CommentsPage` in GitHunt [here](https://github.com/apollographql/GitHunt-React/blob/master/ui/routes/CommentsPage.js).
+You can see the full source code to the `CommentsPage` in GitHunt [here](https://github.com/apollographql/GitHunt-React/blob/master/src/routes/CommentsPage.js).
 
 <h2 id="colocating-fragments">Colocating Fragments</h2>
 
@@ -86,7 +86,7 @@ A key advantage of GraphQL is the tree-like nature of the response data, which i
 
 Although this technique doesn't always make sense (for instance it's not always the case that the GraphQL schema is driven by the UI requirements), when it does, it's possible to use some patterns in Apollo client to take full advantage of it.
 
-In GitHunt, we show an example of this on the [`FeedPage`](https://github.com/apollographql/GitHunt-React/blob/master/ui/routes/FeedPage.js), which constructs the follow view hierarchy:
+In GitHunt, we show an example of this on the [`FeedPage`](https://github.com/apollographql/GitHunt-React/blob/master/src/routes/FeedPage.js), which constructs the follow view hierarchy:
 
 ```
 FeedPage

--- a/source/server-side-rendering.md
+++ b/source/server-side-rendering.md
@@ -176,7 +176,7 @@ export default routes;
 
 ```
 
-You can check out the [GitHunt app's `ui/server.js`](https://github.com/apollographql/GitHunt-React/blob/master/ui/server.js) for a complete working example.
+You can check out the [GitHunt app's `ui/server.js`](https://github.com/apollographql/GitHunt-React/blob/master/src/server.js) for a complete working example.
 
 Next we'll see what that rendering code actually does.
 


### PR DESCRIPTION
URLs using `/ui` were updated to use `/src`.

The URL for files referenced changed in this commit:
https://github.com/apollographql/GitHunt-React/commit/91c3f259af201834254b42143d977f82588c5c3f#diff-935c31f6d60f89156e3f8f203939006e